### PR TITLE
feat: add service_lb_subnet_ids to OKE cluster options

### DIFF
--- a/terraform/oci/oke.tf
+++ b/terraform/oci/oke.tf
@@ -8,6 +8,7 @@ resource "oci_containerengine_cluster" "oke_cluster" {
   name               = var.cluster_name
   vcn_id             = oci_core_vcn.oke_vcn.id
   options {
+    service_lb_subnet_ids = [oci_core_subnet.oke_lb_subnet.id]
     add_ons {
       is_kubernetes_dashboard_enabled = false
       is_tiller_enabled               = false


### PR DESCRIPTION
# About

VCNネイティブ・クラスタへの移行
これで、Kubernetesクラスタと仮想クラウド・ネットワーク(VCN)を完全に統合できます。これは推奨されるベスト・プラクティスです。クラスタの現在のパブリック・エンドポイントは、VCNに統合されていないKubernetes APIです。このクラスタをVCNネイティブのクラスタに移行し、Kubernetes APIエンドポイントをVCNに統合することを強くお薦めします。詳細は、移行のFAQを確認してください。


とのことだったので。