### PR TITLE
feat: terraform cloud用のAgentのdocker-compose.ymlを新規作成

### DIFF
--- a/docker/terraform_cloud/compose.yml
+++ b/docker/terraform_cloud/compose.yml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  tfc-agent:
+    image: hashicorp/tfc-agent:latest
+    container_name: tfc-agent
+    restart: always
+    environment:
+      - TFC_AGENT_TOKEN=xxxxxxxxxx
+      - TFC_AGENT_NAME=${HOSTNAME}


### PR DESCRIPTION
# About

terraform cloudのAgentをdockerで動かすため。
これがないとterraform cloud側でplan/applyができないので、まず先にVMを作って設定しないといけないもの。