### PR TITLE
fix: pt3を非pci-eとしてマウントさせる

### DIFF
--- a/terraform/pve/main.tf
+++ b/terraform/pve/main.tf
@@ -58,7 +58,7 @@ module "prd_rec_server" {
     pci0 = {
       mapping = {
         mapping_id = "earthsoft_pt3"
-        pcie       = true
+        pcie       = false # trueだとq35じゃないと起動しない
       }
     }
   }


### PR DESCRIPTION
# about

vmへのpcieとしてのマウントはq35マシンタイプに限るため。
templateがq35じゃないのでやむなし