### PR TITLE
fix(tnlastation): 録画PVCの書込権限を初期化する

### DIFF
--- a/k8s/pve/tnlastation/README.md
+++ b/k8s/pve/tnlastation/README.md
@@ -26,8 +26,8 @@ TNLAStationを宅内RKE2へdeployするmanifestです。EPGStationとは別の
 
 Bitwarden Secrets Managerへ`TNLASTATION_POSTGRES_PASSWORD`を登録してください。
 
-backendとFFmpeg Workerは、用途別poolとHLSの担当Pod追跡を含む`1.1.0` imageを参照します。
-TNLAStation-backendで`v1.1.0`をreleaseしてからArgo CDで同期してください。
+backendとFFmpeg Workerは`1.1.2`、frontendは`1.1.1` imageを参照します。
+各TNLAStation componentの対応するversionをreleaseしてからArgo CDで同期してください。
 
 TrueNAS `192.168.20.192`へ次のdirectoryが必要です。
 

--- a/k8s/pve/tnlastation/backend.yaml
+++ b/k8s/pve/tnlastation/backend.yaml
@@ -51,7 +51,7 @@ spec:
             - -ec
             - until pg_isready -h postgres.infra-db.svc.cluster.local -U tnlastation -d tnlastation; do sleep 2; done
         - name: migrate
-          image: ghcr.io/miutaku/tnlastation-backend:1.1.1
+          image: ghcr.io/miutaku/tnlastation-backend:1.1.2
           command:
             - dotnet
             - /app/migrator/TNLAStation.Migrator.dll
@@ -67,7 +67,7 @@ spec:
               value: Asia/Tokyo
       containers:
         - name: backend
-          image: ghcr.io/miutaku/tnlastation-backend:1.1.1
+          image: ghcr.io/miutaku/tnlastation-backend:1.1.2
           env:
             - name: ASPNETCORE_ENVIRONMENT
               value: Production

--- a/k8s/pve/tnlastation/backend.yaml
+++ b/k8s/pve/tnlastation/backend.yaml
@@ -32,6 +32,18 @@ spec:
         tnlastation.miutaku.work/config-revision: live-without-re-v2
     spec:
       initContainers:
+        - name: fix-recorded-permissions
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - chown 1654:1654 /recorded && chmod 0775 /recorded
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts:
+            - name: recorded
+              mountPath: /recorded
         - name: wait-for-postgres
           image: postgres:18-bookworm
           command:

--- a/k8s/pve/tnlastation/ffmpeg-worker-encode.yaml
+++ b/k8s/pve/tnlastation/ffmpeg-worker-encode.yaml
@@ -60,7 +60,7 @@ spec:
               app: tnlastation-ffmpeg-worker-encode
       containers:
         - name: ffmpeg-worker
-          image: ghcr.io/miutaku/tnlastation-ffmpeg-worker:1.1.1
+          image: ghcr.io/miutaku/tnlastation-ffmpeg-worker:1.1.2
           env:
             - name: ASPNETCORE_ENVIRONMENT
               value: Production

--- a/k8s/pve/tnlastation/ffmpeg-worker-streaming.yaml
+++ b/k8s/pve/tnlastation/ffmpeg-worker-streaming.yaml
@@ -73,7 +73,7 @@ spec:
               app: tnlastation-ffmpeg-worker-streaming
       containers:
         - name: ffmpeg-worker
-          image: ghcr.io/miutaku/tnlastation-ffmpeg-worker:1.1.1
+          image: ghcr.io/miutaku/tnlastation-ffmpeg-worker:1.1.2
           env:
             - name: ASPNETCORE_ENVIRONMENT
               value: Production

--- a/k8s/pve/tnlastation/frontend.yaml
+++ b/k8s/pve/tnlastation/frontend.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: frontend
-          image: ghcr.io/miutaku/tnlastation-frontend:1.1.0
+          image: ghcr.io/miutaku/tnlastation-frontend:1.1.1
           env:
             - name: NODE_ENV
               value: production
@@ -59,4 +59,3 @@ spec:
               port: http
             initialDelaySeconds: 30
             periodSeconds: 30
-


### PR DESCRIPTION
## 概要

TNLAStation backend を v1.1.1 に更新した後、非root UID 1654 で動作するコンテナが root:root 0755 の録画PVCへ書き込めず、録画が開始直後に破棄されていました。

## 変更

- backend 起動前に録画PVCを 1654:1654 / 0775 に初期化する initContainer を追加

## 検証

- 本番への同等の暫定パッチ後、/recorded が 1654:1654 0775 であることを確認
- TBS「バース・デイ」を含む3番組が is_recording=true となり、m2tsファイルサイズが増加していることを確認
- kubectl kustomize k8s/pve/tnlastation 成功