### PR TITLE
fix(ci): correct rke2_version_watch PR body about upgrade automation

### DIFF
--- a/.github/workflows/rke2_version_watch.yml
+++ b/.github/workflows/rke2_version_watch.yml
@@ -61,9 +61,9 @@ jobs:
           if gh pr view "${branch}" >/dev/null 2>&1; then
             gh pr edit "${branch}" \
               --title "chore(rke2): update ${CURRENT} to ${LATEST}" \
-              --body "Automated RKE2 stable-channel update. Merge does not deploy; review all required checks and run the protected production upgrade workflow separately."
+              --body "Automated RKE2 stable-channel update. Merge does not deploy; there is no automated production upgrade workflow. Perform the rolling upgrade manually per docs/rke2-upgrade.md (rke2_upgrade_validate.yml only runs preflight checks and an Ansible check-mode dry run)."
           else
             gh pr create --base main --head "${branch}" \
               --title "chore(rke2): update ${CURRENT} to ${LATEST}" \
-              --body "Automated RKE2 stable-channel update. Merge does not deploy; review all required checks and run the protected production upgrade workflow separately."
+              --body "Automated RKE2 stable-channel update. Merge does not deploy; there is no automated production upgrade workflow. Perform the rolling upgrade manually per docs/rke2-upgrade.md (rke2_upgrade_validate.yml only runs preflight checks and an Ansible check-mode dry run)."
           fi


### PR DESCRIPTION
## Summary
- The auto-generated PR body for `rke2_version_watch.yml` says to "run the protected production upgrade workflow separately" after merge, implying an automated production upgrade exists.
- No such workflow exists. `rke2_upgrade_validate.yml` only runs preflight checks and an Ansible `--check` (dry-run) pass; it never applies anything.
- The actual rolling upgrade is a manual, well-tested procedure in `docs/rke2-upgrade.md` (one server at a time, gated on kubeletVersion/Ready/API readyz/etcd health, then workers drained one at a time, DVB worker last).
- Updated the PR body text generated by the workflow to point at the manual doc instead of a nonexistent workflow.

## Test plan
- [x] `bash -n .github/workflows/rke2_version_watch.yml`-equivalent: reviewed the diff, only the `--body` string literal changed
- [ ] Next scheduled/manual run of `rke2_version_watch.yml` updates PR #53's body text accordingly