### PR TITLE
fix(ansible/rke2): convert bluetooth_node reboot task to a handler

### DIFF
--- a/ansible/rke2/rke2-agent.yml
+++ b/ansible/rke2/rke2-agent.yml
@@ -55,6 +55,20 @@
     - role: bluetooth_node
       when: bluetooth_controller | default(false) | bool
       tags: bluetooth_node
+
+# Separate play so any reboot handler notified by bluetooth_node (disable-wifi
+# overlay) flushes here, before rke2_agent_node runs — matching the previous
+# inline `reboot` task's position. `roles:` entries cannot contain a bare
+# `meta: flush_handlers` step, so the play boundary is used instead.
+- name: Configure RKE2 Agent Nodes (post-reboot)
+  hosts: rke2-agent
+  strategy: debug
+  gather_facts: false
+  become: true
+  vars:
+    ansible_user: miutaku
+    rke2_node_token: "{{ hostvars[inventory_hostname].rke2_node_token }}"
+  roles:
     - role: cpu_frequency
       when: cpu_frequency_max_khz is defined
       tags: cpu_frequency

--- a/ansible/rke2/rke2-agent.yml
+++ b/ansible/rke2/rke2-agent.yml
@@ -56,10 +56,8 @@
       when: bluetooth_controller | default(false) | bool
       tags: bluetooth_node
 
-# Separate play so any reboot handler notified by bluetooth_node (disable-wifi
-# overlay) flushes here, before rke2_agent_node runs — matching the previous
-# inline `reboot` task's position. `roles:` entries cannot contain a bare
-# `meta: flush_handlers` step, so the play boundary is used instead.
+# Play boundary flushes bluetooth_node's reboot handler before rke2_agent_node
+# runs (roles: can't contain a bare `meta: flush_handlers` entry).
 - name: Configure RKE2 Agent Nodes (post-reboot)
   hosts: rke2-agent
   strategy: debug

--- a/ansible/rke2/roles/bluetooth_node/handlers/main.yml
+++ b/ansible/rke2/roles/bluetooth_node/handlers/main.yml
@@ -3,3 +3,7 @@
   ansible.builtin.service:
     name: bluetooth
     state: restarted
+
+- name: Reboot to apply disable-wifi overlay
+  ansible.builtin.reboot:
+    reboot_timeout: 180

--- a/ansible/rke2/roles/bluetooth_node/tasks/main.yml
+++ b/ansible/rke2/roles/bluetooth_node/tasks/main.yml
@@ -39,9 +39,4 @@
     line: "dtoverlay=disable-wifi"
     insertafter: '^dtoverlay=dwc2$'
     state: present
-  register: disable_wifi_overlay
-
-- name: Reboot to apply disable-wifi overlay
-  ansible.builtin.reboot:
-    reboot_timeout: 180
-  when: disable_wifi_overlay.changed
+  notify: Reboot to apply disable-wifi overlay


### PR DESCRIPTION
## Summary
- `ansible-lint`'s `no-handler` rule fails on PR #53 (RKE2 v1.35.7 patch bump) because of a pre-existing issue in `bluetooth_node`, unrelated to the version change itself.
- The "Reboot to apply disable-wifi overlay" task used `register: disable_wifi_overlay` + `when: disable_wifi_overlay.changed` instead of the standard `notify:` handler pattern.

## Change
- Moved the reboot into `roles/bluetooth_node/handlers/main.yml`, notified from the WiFi-disable task (same pattern already used by the existing "Restarted bluetooth service" handler in this role).
- The original inline task rebooted immediately, before `cpu_frequency`/`rke2_agent_node`/`rke2_all_node` ran in the same play. A bare `meta: flush_handlers` is not valid as a `roles:` list entry (confirmed via `ansible-lint`'s syntax-check: "role definitions must contain a role name"), so `rke2-agent.yml`'s single play is split into two consecutive plays for the same `rke2-agent` hosts, at the point right after `bluetooth_node`. Ansible flushes notified handlers at the end of a play automatically, so this reproduces the original timing without an explicit flush step. The second play uses `gather_facts: false` to keep the same (pre-reboot) fact values the subsequent roles previously saw, rather than silently changing behavior.
- Only affects `worker-11`/`worker-12` (the two Raspberry Pi agents with `bluetooth_controller: true`); hosts without that flag skip `bluetooth_node` entirely and the extra play boundary is a no-op for them.

## Test plan
Run locally in `ansible/rke2` (pipenv, matching CI):
- [x] `pipenv run ansible-lint site.yml` — 0 failures (previously 1 fatal `no-handler` violation)
- [x] `pipenv run ansible-playbook site.yml --syntax-check`
- [x] `pipenv run ansible-playbook -i hosts/prd site.yml --syntax-check`
- [x] `pipenv run ansible-playbook -i hosts/prd site.yml --check --list-tasks` — confirms the play split lands exactly where intended (bluetooth_node ends play #4, cpu_frequency starts play #5)

No behavior change intended for non-RPi hosts; RPi hosts keep rebooting at the same point in the run, just via a handler instead of an inline task.