### PR TITLE
fix(oci/arc): bump oke-rke2-admin runner image past GitHub's deprecation cutoff

### DIFF
--- a/k8s/oci/argocd-apps/arc-runner-rke2.yaml
+++ b/k8s/oci/argocd-apps/arc-runner-rke2.yaml
@@ -31,7 +31,7 @@ spec:
               kubernetes.io/os: linux
             containers:
               - name: runner
-                image: ghcr.io/actions/actions-runner:2.334.0
+                image: ghcr.io/actions/actions-runner:2.336.0
                 command: ["/home/runner/run.sh"]
                 resources:
                   requests:


### PR DESCRIPTION
## Summary
`live-rke2-preflight` on PR #53 (and now #56/#57) has been stuck `queued` for over an hour. Root-caused via live investigation on the OKE cluster (controller logs, ArgoCD status, upstream issue search) — not related to RKE2 itself.

## Root cause
1. The pinned runner image `ghcr.io/actions/actions-runner:2.334.0` fell below GitHub's currently-enforced minimum self-hosted runner version. New registrations from it are rejected as deprecated (exit code 7).
2. ARC's controller treats a deprecated runner as "outdated" and tears down the `AutoscalingRunnerSet` (listener, `EphemeralRunnerSet`, and the GitHub-side runner-scale-set registration) to recreate it.
3. `gha-runner-scale-set-controller` 0.14.2 (current latest — there is no newer chart release) has two known, still-open upstream bugs that combine here:
   - [actions/actions-runner-controller#4600](https://github.com/actions/actions-runner-controller/issues/4600): the `DeleteRunnerScaleSet` call made during that teardown has no request deadline / unbounded reconcile context. If it ever hangs, the single `AutoscalingRunnerSet` reconcile worker wedges permanently.
   - [actions/actions-runner-controller#4595](https://github.com/actions/actions-runner-controller/issues/4595): once `status.phase` is persisted as `Outdated` with cleanup already completed, the controller never logs or reconciles that resource again — restarting the controller pod just re-enters and re-hangs on the same delete call, since phase is stored in status and its only exit path is a *successful* full cleanup+recreate.
4. This matches what was observed exactly: `oci-arc-systems-gha-rs-controller` pod stayed `Ready` throughout, zero further log output for `oke-rke2-admin`, `kubectl get autoscalinglisteners` empty, 0 runners, unaffected by controller pod restarts, a GitHub PAT rotation, or recreating the `AutoscalingRunnerSet` object itself (which briefly got further — created a runner, immediately re-marked it outdated because it's still the same deprecated image — before wedging again).

## Fix
Bump the pinned runner image to `ghcr.io/actions/actions-runner:2.336.0` (current `actions/runner` latest), which is above GitHub's deprecation cutoff, so the controller has no reason to mark it outdated and re-enter the teardown path that can wedge.

## Scope note
Unrelated to the RKE2 v1.35.7 patch upgrade itself (PR #53) — split out per the same "focused PR" pattern as #56/#57, since this is a pre-existing infra issue blocking the live-preflight validation gate rather than something introduced by the version bump.

## Verification plan
Once merged, ArgoCD (`selfHeal: true`) will sync the new pod template onto the already-wedged `AutoscalingRunnerSet`, which changes its spec hash and should trigger one more outdated→recreate cycle — this time landing on a non-deprecated image so it should stabilize with a running listener instead of wedging again. Will confirm live: `autoscalinglisteners` gets created, `live-rke2-preflight` moves off `queued`.