### PR TITLE
fix(pve/epgstation): fail fast in config-init initContainer

### DIFF
--- a/k8s/pve/epgstation/epgstation-deployment.yaml
+++ b/k8s/pve/epgstation/epgstation-deployment.yaml
@@ -36,6 +36,7 @@ spec:
             - sh
             - -c
             - |
+              set -eu
               apk add --no-cache gettext
               mkdir -p /app/config/enc
               for f in /config-src/config.yml /config-src/notify.sh \


### PR DESCRIPTION
## Summary
Discovered while investigating why `live-rke2-preflight` (unrelated RKE2 upgrade work, PR #53/#56/#57) was failing its cluster-wide workload-readiness check: EPGStation had been `CrashLoopBackOff` for 6+ days (1244 restarts), unrelated to any of that work.

## Root cause
- Crash: `TypeError: Cannot read properties of undefined (reading 'mirakurunPath')` in `Configuration.setTemplateValues` — happens when `js-yaml` parses an **empty** `config.yml` (confirmed against upstream l3tnun/EPGStation `v2.10.0` source: `setTemplateValues(config)` is called with `config === undefined`, which only happens when `yaml.load()` on the file content returns `undefined`, i.e. an empty document).
- The `config-init` initContainer's own logs (still present on the stuck pod) show why: at pod startup on 2026-08-11, `apk add --no-cache gettext` hit `WARNING: fetching https://dl-cdn.alpinelinux.org/alpine/v3.20/main: temporary error (try again later)` and failed, so `envsubst` didn't exist (`sh: envsubst: not found` × 6).
- The script has no `set -e`. Each `envsubst '...' < "$f" > "/app/config/$(basename $f)"` still ran (shell still creates/truncates the output file for the redirect even though the command itself fails to start), so all 6 generated files — including `config.yml` — ended up 0 bytes.
- The initContainer exited **0** regardless, so nothing about the pod's init status flagged a problem.
- `config`/`app/config` is an `emptyDir`, populated only when initContainers run on a *new* pod — not on container restarts. So the one bad run from 6 days ago kept feeding an empty `config.yml` to every one of the 1244 restarts since.

## Fix
- **Live cluster (already done, not part of this PR's diff):** deleted the stuck pod; the Deployment rescheduled it, initContainers reran against a fresh `emptyDir`, and `apk add gettext` succeeded this time (the CDN issue was transient). EPGStation is healthy again — confirmed via its own startup log (`config.yml read success`, `check mirakurun`, `check db`, reservation updates completing) and `kubectl get deploy epgstation` showing `1/1` ready.
- **This PR:** adds `set -eu` to the `config-init` initContainer script, so the *next* time `apk add` (or anything else in that script) fails, the initContainer fails loudly (`Init:Error`, visible in `kubectl get pods`) instead of silently producing empty config files that only surface later as a cryptic crash in the main container.

## Test plan
- [x] Live-verified the immediate recovery (pod `Running`/`Ready`, 0 restarts, healthy startup log, `Deployment` `1/1`).
- [x] Live-verified this run's `config-init` log shows `gettext` actually installing (`OK: 14 MiB in 24 packages`).
- Not exercised by any existing CI (no ArgoCD/kustomize build check currently covers `k8s/pve/epgstation/**`); this is a targeted, minimal change to an already-working (as of this PR) initContainer script.