### PR TITLE
feat(oke): replace ingress-nginx with NGINX Gateway Fabric (empty)

### DIFF
--- a/k8s/oci-prd/argocd-apps/gateway-api-crds.yaml
+++ b/k8s/oci-prd/argocd-apps/gateway-api-crds.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: oci-prd-gateway-api-crds
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/nginx/nginx-gateway-fabric.git
+    targetRevision: v2.6.7
+    path: config/crd/gateway-api/standard
+  destination:
+    name: oke-prd
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/k8s/oci-prd/argocd-apps/nginx-gateway-fabric.yaml
+++ b/k8s/oci-prd/argocd-apps/nginx-gateway-fabric.yaml
@@ -1,35 +1,37 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: oci-prd-ingress-nginx
+  name: oci-prd-nginx-gateway-fabric
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
-    argocd.argoproj.io/sync-wave: "3"
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   project: default
   source:
-    repoURL: https://kubernetes.github.io/ingress-nginx
-    chart: ingress-nginx
-    targetRevision: "4.11.3"
+    repoURL: oci://ghcr.io/nginx/charts/nginx-gateway-fabric
+    chart: nginx-gateway-fabric
+    targetRevision: "2.6.7"
     helm:
-      releaseName: ingress-nginx
+      releaseName: nginx-gateway-fabric
       valuesObject:
-        controller:
+        nginxGateway:
           nodeSelector:
             kubernetes.io/arch: arm64
+        nginx:
           service:
+            type: LoadBalancer
             annotations:
+              # OCI Always Free: 10Mbps flexible shape (旧ingress-nginxと同条件)
               service.beta.kubernetes.io/oci-load-balancer-shape: "flexible"
               service.beta.kubernetes.io/oci-load-balancer-shape-flex-min: "10"
               service.beta.kubernetes.io/oci-load-balancer-shape-flex-max: "10"
-          config:
-            use-forwarded-headers: "true"
-            compute-full-forwarded-for: "true"
+          nodeSelector:
+            kubernetes.io/arch: arm64
   destination:
     name: oke-prd
-    namespace: ingress-nginx
+    namespace: nginx-gateway
   syncPolicy:
     automated:
       prune: true

--- a/k8s/oci/argocd-apps/gateway-api-crds.yaml
+++ b/k8s/oci/argocd-apps/gateway-api-crds.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: oci-gateway-api-crds
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/nginx/nginx-gateway-fabric.git
+    targetRevision: v2.6.7
+    path: config/crd/gateway-api/standard
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/k8s/oci/argocd-apps/nginx-gateway-fabric.yaml
+++ b/k8s/oci/argocd-apps/nginx-gateway-fabric.yaml
@@ -1,36 +1,37 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: oci-ingress-nginx
+  name: oci-nginx-gateway-fabric
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
-    argocd.argoproj.io/sync-wave: "3"
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   project: default
   source:
-    repoURL: https://kubernetes.github.io/ingress-nginx
-    chart: ingress-nginx
-    targetRevision: "4.11.3"
+    repoURL: oci://ghcr.io/nginx/charts/nginx-gateway-fabric
+    chart: nginx-gateway-fabric
+    targetRevision: "2.6.7"
     helm:
-      releaseName: ingress-nginx
+      releaseName: nginx-gateway-fabric
       valuesObject:
-        controller:
+        nginxGateway:
           nodeSelector:
             kubernetes.io/arch: arm64
+        nginx:
           service:
+            type: LoadBalancer
             annotations:
-              # OCI Always Free: 10Mbps flexible shape
+              # OCI Always Free: 10Mbps flexible shape (旧ingress-nginxと同条件)
               service.beta.kubernetes.io/oci-load-balancer-shape: "flexible"
               service.beta.kubernetes.io/oci-load-balancer-shape-flex-min: "10"
               service.beta.kubernetes.io/oci-load-balancer-shape-flex-max: "10"
-          config:
-            use-forwarded-headers: "true"
-            compute-full-forwarded-for: "true"
+          nodeSelector:
+            kubernetes.io/arch: arm64
   destination:
     server: https://kubernetes.default.svc
-    namespace: ingress-nginx
+    namespace: nginx-gateway
   syncPolicy:
     automated:
       prune: true

--- a/k8s/oci/argocd/README.md
+++ b/k8s/oci/argocd/README.md
@@ -86,7 +86,8 @@ kubectl apply -f k8s/oci/argocd/root-app.yaml
 | 1 | oci-cert-manager | cert-manager (CRD 含む) |
 | 1 | oci-longhorn | Longhorn |
 | 2 | oci-cert-manager-config | ClusterIssuer (Let's Encrypt) |
-| 3 | oci-ingress-nginx | ingress-nginx |
+| 1 | oci-gateway-api-crds | Gateway API CRD (standard channel, NGF同梱版) |
+| 2 | oci-nginx-gateway-fabric | NGINX Gateway Fabric (GatewayClassのみ・Gateway未作成) |
 | 4 | oci-cloudflared | Cloudflare Tunnel |
 | 1 | oci-arc-controller / oci-arc-runners-config | Actions Runner Controller + credentials |
 | 2 | oci-arc-runner-rke2 | `my-infra` RKE2 preflight用ephemeral runner scale set |


### PR DESCRIPTION
## Summary
- Remove ingress-nginx (STG+PRD): confirmed zero real traffic — the only `Ingress` resource in the repo was encode-worker's (removed separately), and every public hostname's DNS record resolves to the Cloudflare Tunnel, never to ingress-nginx's LoadBalancer IP.
- Install Gateway API standard-channel CRDs, pinned to NGF's own vendored copy at the same tag as the controller (v2.6.7) to keep them in lockstep.
- Install NGINX Gateway Fabric itself in an empty, ready state (GatewayClass only, no Gateway/HTTPRoute yet) — for future Gateway API-based publishing, mirroring ingress-nginx's OCI Always Free LB shape + arm64 nodeSelector.
- Applied symmetrically to both STG and PRD OKE clusters.
- No `terraform/oci/network.tf` change: the `lb_sl` security list's 443/80 Cloudflare-only rules are subnet-scoped, not tied to a specific Service, so they already cover NGF's new LoadBalancer.

## Test plan
- [x] YAML valid for all new/changed manifests
- [ ] CI (`k8s_check_oci` kustomize-build) green
- [ ] Post-merge STG: `kubectl get pods -n nginx-gateway` Running, `kubectl get gatewayclass nginx` exists, `ingress-nginx` namespace gone, new LB EXTERNAL-IP assigned
- [ ] Post-merge PRD: same checks against the `oke-prd` cluster