### PR TITLE
fix(oke-prd): make ingress-nginx-controller HA (2 replicas + anti-affinity)

### DIFF
--- a/k8s/oci-prd/argocd-apps/ingress-nginx.yaml
+++ b/k8s/oci-prd/argocd-apps/ingress-nginx.yaml
@@ -17,8 +17,18 @@ spec:
       releaseName: ingress-nginx
       valuesObject:
         controller:
+          replicaCount: 2
           nodeSelector:
             kubernetes.io/arch: arm64
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: ingress-nginx
+                      app.kubernetes.io/instance: ingress-nginx
+                      app.kubernetes.io/component: controller
           service:
             annotations:
               service.beta.kubernetes.io/oci-load-balancer-shape: "flexible"


### PR DESCRIPTION
## Summary
- \`controller.replicaCount: 2\` for oci-prd's ingress-nginx (was 1, no PDB — the chart auto-creates a PDB with minAvailable:1 once replicaCount > 1)
- Hard pod anti-affinity so the 2 replicas always land on different nodes

## Why
Re:Venter production traffic all flows through this single ingress-nginx-controller pod, which was sharing a node with backend (also just fixed in the reventer repo). Prerequisite for a zero-downtime OKE node version upgrade — see companion PR in reventer#403 (merged).

## Test plan
- [x] YAML valid
- [ ] CI green
- [ ] Post-merge: confirm 2/2 controller pods on separate nodes, PDB exists, re-venter.com / api.re-venter.com stay reachable throughout