### PR TITLE
fix(ngf): avoid Pending during rolling update on tight-capacity nodes

### DIFF
--- a/k8s/oci-prd/argocd-apps/nginx-gateway-fabric.yaml
+++ b/k8s/oci-prd/argocd-apps/nginx-gateway-fabric.yaml
@@ -51,6 +51,15 @@ spec:
                       matchExpressions:
                         - key: gateway.networking.k8s.io/gateway-name
                           operator: Exists
+          # ノード2台上限でもロールアウト中にPendingが出ないよう、surgeせず1台ずつ入れ替える
+          patches:
+            - type: StrategicMerge
+              value:
+                spec:
+                  strategy:
+                    rollingUpdate:
+                      maxSurge: 0
+                      maxUnavailable: 1
           service:
             type: LoadBalancer
             # service.annotationsはこのCRDに存在しないフィールド
@@ -116,6 +125,15 @@ spec:
   destination:
     name: oke-prd
     namespace: nginx-gateway
+  ignoreDifferences:
+    # control-planeにはchart側のpatches機構が無いため直接kubectl patchする。
+    # selfHealで打ち消されないようdiff計算から除外。
+    - group: apps
+      kind: Deployment
+      name: nginx-gateway-fabric
+      namespace: nginx-gateway
+      jsonPointers:
+        - /spec/strategy
   syncPolicy:
     automated:
       prune: true

--- a/k8s/oci/argocd-apps/nginx-gateway-fabric.yaml
+++ b/k8s/oci/argocd-apps/nginx-gateway-fabric.yaml
@@ -56,6 +56,15 @@ spec:
                         matchExpressions:
                           - key: gateway.networking.k8s.io/gateway-name
                             operator: Exists
+          # 2ノード未満でもロールアウト中にPendingが出ないよう、surgeせず1台ずつ入れ替える
+          patches:
+            - type: StrategicMerge
+              value:
+                spec:
+                  strategy:
+                    rollingUpdate:
+                      maxSurge: 0
+                      maxUnavailable: 1
           service:
             type: LoadBalancer
             # service.annotationsはこのCRDに存在しないフィールド
@@ -121,6 +130,15 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: nginx-gateway
+  ignoreDifferences:
+    # control-planeにはchart側のpatches機構が無いため直接kubectl patchする。
+    # selfHealで打ち消されないようdiff計算から除外。
+    - group: apps
+      kind: Deployment
+      name: nginx-gateway-fabric
+      namespace: nginx-gateway
+      jsonPointers:
+        - /spec/strategy
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Summary
- NGINX Gateway FabricのDeployment(control-plane/data-plane)はデフォルトのrolling update戦略(`maxSurge=25%`≒2 replica構成で実質+1)を使っており、ロールアウト中に一時的に3台分のPod枠が必要になる
- STG(1ノード)/PRD(2ノード上限)ともノードのCPU requestsがほぼ使い切られており、この一時的な3台目がスケジュールできず`Pending`のまま詰まる問題が今回発生した
- `maxSurge:0, maxUnavailable:1`にすることで、常に2台以内で1台ずつ入れ替える方式に変更し、再発を防ぐ

## Test plan
- [ ] STGでArgoCD sync後、`NginxProxy`経由でdata-plane Deploymentの`spec.strategy`が反映されることを確認
- [ ] control-plane Deploymentへ`kubectl patch`を適用し、`ignoreDifferences`によってselfHealで打ち消されないことを確認
- [ ] STGで実際に何らかのvalues変更を行いロールアウトさせ、Pendingが発生しないことを確認
- [ ] 問題なければPRDにも同じ手順を適用