### PR TITLE
fix: align PRD gateway replicas with base capacity

### DIFF
--- a/k8s/oci-prd/argocd-apps/nginx-gateway-fabric.yaml
+++ b/k8s/oci-prd/argocd-apps/nginx-gateway-fabric.yaml
@@ -20,7 +20,9 @@ spec:
       skipCrds: true
       valuesObject:
         nginxGateway:
-          replicas: 2
+          # PRDの定常base node poolは1台。GatewayはBlue/Greenの切替対象外なので、
+          # control-plane/data-planeとも定常1 replicaとし、burst nodeを0台へ戻せるようにする。
+          replicas: 1
           nodeSelector:
             kubernetes.io/arch: arm64
           resources:
@@ -36,7 +38,7 @@ spec:
                       app.kubernetes.io/name: nginx-gateway-fabric
                       app.kubernetes.io/instance: nginx-gateway-fabric
         nginx:
-          replicas: 2
+          replicas: 1
           container:
             resources:
               requests:
@@ -51,7 +53,7 @@ spec:
                       matchExpressions:
                         - key: gateway.networking.k8s.io/gateway-name
                           operator: Exists
-          # ノード2台上限でもロールアウト中にPendingが出ないよう、surgeせず1台ずつ入れ替える
+          # 単一baseノードでも更新時に余分なPodを要求しないよう、surgeせず入れ替える
           patches:
             - type: StrategicMerge
               value:


### PR DESCRIPTION
## Summary
- run NGINX Gateway Fabric control-plane with one steady replica
- run the PRD Gateway data-plane with one steady replica
- align Gateway scheduling with the single-node PRD base pool while keeping burst at zero normally

## Context
During the PRD Blue/Green infrastructure rollout, both Gateway Deployments remained at 2 replicas with required pod anti-affinity. A single steady base node could therefore never schedule the second replicas, keeping Argo CD Progressing and preventing a clean burst scale-down.

## Validation
- YAML parse passed
- Argo CD Application server-side dry-run passed
- live PRD override is 1/1 for both Deployments and public frontend/backend health checks pass